### PR TITLE
fix: @CacheEvict 이벤트시, 해당 캐시 이름의 해당되는 데이터를 모두 삭제하도록 버그 수정

### DIFF
--- a/query/src/main/kotlin/com/hs/application/usecase/ProductAggregateCommand.kt
+++ b/query/src/main/kotlin/com/hs/application/usecase/ProductAggregateCommand.kt
@@ -21,7 +21,7 @@ class ProductAggregateCommand(
 
     @Caching(
         evict = [
-            CacheEvict(value = ["productAggregate"], key = "#productId", cacheManager = "redisCacheManager"),
+            CacheEvict(key = "#productId", cacheResolver = "productAggregateCacheEvictResolver"),
 //            CacheEvict(
 //                value = ["productAggregatePage"],
 //                key = "#productId",

--- a/query/src/main/kotlin/com/hs/config/redis/RedisConfig.kt
+++ b/query/src/main/kotlin/com/hs/config/redis/RedisConfig.kt
@@ -3,6 +3,7 @@ package com.hs.config.redis
 import com.hs.dto.FindPaginationDto
 import com.hs.dto.FindProductAggregateDto
 import com.hs.infrastructure.redis.keygenerator.ProductAggregateCacheKeyGenerator
+import com.hs.infrastructure.redis.resolver.ProductAggregateCacheEvictResolver
 import com.hs.infrastructure.redis.resolver.ProductAggregatePageCacheEvictResolver
 import com.hs.infrastructure.redis.resolver.ProductAggregateCacheableResolver
 import org.springframework.beans.factory.annotation.Value
@@ -125,6 +126,15 @@ class RedisConfig(
             productAggregateRedisTemplate = productAggregateRedisTemplate()
         )
     }
+
+    @Bean
+    fun productAggregateCacheEvictResolver(): CacheResolver {
+        return ProductAggregateCacheEvictResolver(
+            redisCacheManager = redisCacheManager(),
+            productAggregateRedisTemplate = productAggregateRedisTemplate()
+        )
+    }
+
 
     @Bean
     fun productAggregatePageCacheEvictResolver(): CacheResolver {

--- a/query/src/main/kotlin/com/hs/infrastructure/redis/resolver/ProductAggregateCacheEvictResolver.kt
+++ b/query/src/main/kotlin/com/hs/infrastructure/redis/resolver/ProductAggregateCacheEvictResolver.kt
@@ -1,0 +1,35 @@
+package com.hs.infrastructure.redis.resolver
+
+import com.hs.config.redis.RedisConfig
+import com.hs.dto.FindProductAggregateDto
+import org.springframework.cache.Cache
+import org.springframework.cache.interceptor.CacheOperationInvocationContext
+import org.springframework.cache.interceptor.CacheResolver
+import org.springframework.data.redis.cache.RedisCacheManager
+import org.springframework.data.redis.connection.RedisConnection
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.serializer.RedisSerializer
+
+class ProductAggregateCacheEvictResolver(
+    private val redisCacheManager: RedisCacheManager,
+    private val productAggregateRedisTemplate: RedisTemplate<String, FindProductAggregateDto>
+) : CacheResolver {
+
+    override fun resolveCaches(context: CacheOperationInvocationContext<*>): MutableCollection<out Cache> {
+        delete(productId = context.args[0].toString())
+
+        return mutableListOf(redisCacheManager.getCache(RedisConfig.PRODUCT_AGGREGATE_CACHE_NAME)!!)
+    }
+
+    private fun delete(productId: String) {
+        val keySerializer: RedisSerializer<String> = productAggregateRedisTemplate.stringSerializer
+
+        productAggregateRedisTemplate.executePipelined { connection: RedisConnection ->
+            (0 until RedisConfig.PRODUCT_AGGREGATE_COPY_COUNT)
+                .map { "${RedisConfig.PRODUCT_AGGREGATE_CACHE_NAME}::copy-${it}::${productId}" }
+                .forEach { connection.del(keySerializer.serialize(it)) }
+
+            return@executePipelined null
+        }
+    }
+}


### PR DESCRIPTION
- Redis Pipeline 사용하여 한 번에 많은 데이터 삭제시, 네트워크 병목 개선

resolve #58